### PR TITLE
Move application configuration out into its own Configuration class.

### DIFF
--- a/src/main/kotlin/au/kilemon/messagequeue/MessageQueueApplication.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/MessageQueueApplication.kt
@@ -35,47 +35,6 @@ open class MessageQueueApplication : HasLogger
          */
         const val VERSION: String = "0.1.6"
     }
-
-    @Autowired
-    @get:Generated
-    @set:Generated
-    lateinit var messageQueueSettings: MessageQueueSettings
-
-    @Autowired
-    @get:Generated
-    @set:Generated
-    lateinit var messageSource: ReloadableResourceBundleMessageSource
-
-    /**
-     * Initialise the [MultiQueue] [Bean] based on the [MessageQueueSettings.multiQueueType].
-     */
-    @Bean
-    open fun getMultiQueue(): MultiQueue
-    {
-        LOG.info(messageSource.getMessage(Messages.VERSION_START_UP, null, Locale.getDefault()), VERSION)
-        val queue: MultiQueue = when (messageQueueSettings.multiQueueType)
-        {
-            MultiQueueType.IN_MEMORY.toString() ->
-            {
-                InMemoryMultiQueue()
-            }
-            MultiQueueType.REDIS.toString() ->
-            {
-                RedisMultiQueue()
-            }
-            MultiQueueType.SQL.toString() ->
-            {
-                SqlMultiQueue()
-            }
-            else ->
-            {
-                InMemoryMultiQueue()
-            }
-        }
-        LOG.info("Initialising [{}] queue as the [{}] is set to [{}].", queue::class.java.name, MessageQueueSettings.MULTI_QUEUE_TYPE, messageQueueSettings.multiQueueType)
-
-        return queue
-    }
 }
 
 /**

--- a/src/main/kotlin/au/kilemon/messagequeue/configuration/QueueConfiguration.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/configuration/QueueConfiguration.kt
@@ -1,0 +1,71 @@
+package au.kilemon.messagequeue.configuration
+
+import au.kilemon.messagequeue.MessageQueueApplication
+import au.kilemon.messagequeue.logging.HasLogger
+import au.kilemon.messagequeue.logging.Messages
+import au.kilemon.messagequeue.queue.MultiQueue
+import au.kilemon.messagequeue.queue.cache.redis.RedisMultiQueue
+import au.kilemon.messagequeue.queue.inmemory.InMemoryMultiQueue
+import au.kilemon.messagequeue.queue.sql.SqlMultiQueue
+import au.kilemon.messagequeue.settings.MessageQueueSettings
+import au.kilemon.messagequeue.settings.MultiQueueType
+import lombok.Generated
+import org.slf4j.Logger
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.support.ReloadableResourceBundleMessageSource
+import java.util.*
+
+/**
+ * A [Configuration] class holding all required [Bean]s for the [MessageQueueApplication] to run.
+ * Mainly [Bean]s related to the [MultiQueue].
+ *
+ * @author github.com/KyleGonzalez
+ */
+@Configuration
+class QueueConfiguration : HasLogger
+{
+    override val LOG: Logger = initialiseLogger()
+
+    @Autowired
+    @get:Generated
+    @set:Generated
+    lateinit var messageQueueSettings: MessageQueueSettings
+
+    @Autowired
+    @get:Generated
+    @set:Generated
+    lateinit var messageSource: ReloadableResourceBundleMessageSource
+
+    /**
+     * Initialise the [MultiQueue] [Bean] based on the [MessageQueueSettings.multiQueueType].
+     */
+    @Bean
+    open fun getMultiQueue(): MultiQueue
+    {
+        LOG.info(messageSource.getMessage(Messages.VERSION_START_UP, null, Locale.getDefault()), MessageQueueApplication.VERSION)
+        val queue: MultiQueue = when (messageQueueSettings.multiQueueType)
+        {
+            MultiQueueType.IN_MEMORY.toString() ->
+            {
+                InMemoryMultiQueue()
+            }
+            MultiQueueType.REDIS.toString() ->
+            {
+                RedisMultiQueue()
+            }
+            MultiQueueType.SQL.toString() ->
+            {
+                SqlMultiQueue()
+            }
+            else ->
+            {
+                InMemoryMultiQueue()
+            }
+        }
+        LOG.info("Initialising [{}] queue as the [{}] is set to [{}].", queue::class.java.name, MessageQueueSettings.MULTI_QUEUE_TYPE, messageQueueSettings.multiQueueType)
+
+        return queue
+    }
+}

--- a/src/main/kotlin/au/kilemon/messagequeue/queue/sql/SqlMultiQueue.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/queue/sql/SqlMultiQueue.kt
@@ -24,12 +24,6 @@ class SqlMultiQueue : MultiQueue, HasLogger
 {
     override val LOG: Logger = initialiseLogger()
 
-    @Autowired
-    @Lazy
-    @get:Generated
-    @set:Generated
-    lateinit var messageQueueSettings: MessageQueueSettings
-
     @Lazy
     @Autowired
     private lateinit var queueMessageRepository: QueueMessageRepository

--- a/src/test/kotlin/au/kilemon/messagequeue/queue/AbstractMultiQueueTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/queue/AbstractMultiQueueTest.kt
@@ -3,14 +3,20 @@ package au.kilemon.messagequeue.queue
 import au.kilemon.messagequeue.message.QueueMessage
 import au.kilemon.messagequeue.queue.exception.DuplicateMessageException
 import au.kilemon.messagequeue.queue.inmemory.InMemoryMultiQueue
+import au.kilemon.messagequeue.queue.sql.SqlMultiQueue
 import au.kilemon.messagequeue.rest.model.Payload
 import au.kilemon.messagequeue.rest.model.PayloadEnum
+import au.kilemon.messagequeue.settings.MessageQueueSettings
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Lazy
 import java.io.Serializable
 import java.util.*
 import java.util.stream.Stream
@@ -26,10 +32,30 @@ import kotlin.collections.HashSet
  * @author github.com/KyleGonzalez
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-abstract class AbstractMultiQueueTest<T: MultiQueue>
+abstract class AbstractMultiQueueTest
 {
+    /**
+     * A Spring configuration that is used for this test class.
+     *
+     * @author github.com/KyleGonzalez
+     */
+    @TestConfiguration
+    class AbstractMultiQueueTestConfiguration
+    {
+        /**
+         * The bean initialise here will have all its properties overridden by environment variables.
+         * Don't set them here, set them in the [WebMvcTest.properties].
+         */
+        @Bean
+        @Lazy
+        open fun getMessageQueueSettingsBean(): MessageQueueSettings
+        {
+            return MessageQueueSettings()
+        }
+    }
+
     @Autowired
-    protected lateinit var multiQueue: T
+    protected lateinit var multiQueue: MultiQueue
 
     /**
      * Ensure that when a new entry is added, that the [MultiQueue] is no longer empty and reports the correct size.

--- a/src/test/kotlin/au/kilemon/messagequeue/queue/cache/redis/RedisSentinelMultiQueueTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/queue/cache/redis/RedisSentinelMultiQueueTest.kt
@@ -1,6 +1,8 @@
 package au.kilemon.messagequeue.queue.cache.redis
 
+import au.kilemon.messagequeue.configuration.QueueConfiguration
 import au.kilemon.messagequeue.configuration.cache.redis.RedisConfiguration
+import au.kilemon.messagequeue.logging.LoggingConfiguration
 import au.kilemon.messagequeue.queue.AbstractMultiQueueTest
 import au.kilemon.messagequeue.settings.MessageQueueSettings
 import org.junit.jupiter.api.AfterAll
@@ -37,8 +39,8 @@ import java.util.*
 @TestPropertySource(properties = ["${MessageQueueSettings.MULTI_QUEUE_TYPE}=REDIS"])
 @Testcontainers
 @ContextConfiguration(initializers = [RedisSentinelMultiQueueTest.Initializer::class])
-@Import(RedisConfiguration::class)
-class RedisSentinelMultiQueueTest: AbstractMultiQueueTest<RedisMultiQueue>()
+@Import(*[QueueConfiguration::class, LoggingConfiguration::class, RedisConfiguration::class, AbstractMultiQueueTest.AbstractMultiQueueTestConfiguration::class])
+class RedisSentinelMultiQueueTest: AbstractMultiQueueTest()
 {
     companion object
     {
@@ -94,49 +96,6 @@ class RedisSentinelMultiQueueTest: AbstractMultiQueueTest<RedisMultiQueue>()
                 "${MessageQueueSettings.REDIS_ENDPOINT}=${sentinel.host}:${sentinel.getMappedPort(RedisConfiguration.REDIS_SENTINEL_DEFAULT_PORT.toInt())}",
                 "${MessageQueueSettings.REDIS_USE_SENTINELS}=${true}"
             ).applyTo(configurableApplicationContext.environment)
-        }
-    }
-
-    /**
-     * A Spring configuration that is used for this test class.
-     * Creates a [RedisSentinelConfiguration] as the [RedisConnectionFactory] [Bean].
-     *
-     * This is specifically creating the [RedisMultiQueue] to be autowired in the parent
-     * class and used in all the tests.
-     *
-     * @author github.com/KyleGonzalez
-     */
-    @TestConfiguration
-    internal class RedisSentinelTestConfiguration
-    {
-        @Autowired
-        @Lazy
-        lateinit var connectionFactory: RedisConnectionFactory
-
-        @Autowired
-        @Lazy
-        lateinit var messageQueueSettings: MessageQueueSettings
-
-        /**
-         * The bean initialise here will have all its properties overridden by environment variables.
-         * Don't set the here, set them in the [WebMvcTest.properties].
-         */
-        @Bean
-        @Lazy
-        open fun getMessageQueueSettingsBean(): MessageQueueSettings
-        {
-            return MessageQueueSettings()
-        }
-
-        /**
-         * The bean initialise here will have all its properties overridden by environment variables.
-         * Don't set the here, set them in the [WebMvcTest.properties].
-         */
-        @Bean
-        @Lazy
-        open fun getRedisMultiQueue(): RedisMultiQueue
-        {
-            return RedisMultiQueue()
         }
     }
 

--- a/src/test/kotlin/au/kilemon/messagequeue/queue/cache/redis/RedisStandAloneMultiQueueTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/queue/cache/redis/RedisStandAloneMultiQueueTest.kt
@@ -1,6 +1,8 @@
 package au.kilemon.messagequeue.queue.cache.redis
 
+import au.kilemon.messagequeue.configuration.QueueConfiguration
 import au.kilemon.messagequeue.configuration.cache.redis.RedisConfiguration
+import au.kilemon.messagequeue.logging.LoggingConfiguration
 import au.kilemon.messagequeue.queue.AbstractMultiQueueTest
 import au.kilemon.messagequeue.settings.MessageQueueSettings
 import org.junit.jupiter.api.AfterAll
@@ -46,8 +48,8 @@ import java.util.*
 @TestPropertySource(properties = ["${MessageQueueSettings.MULTI_QUEUE_TYPE}=REDIS", "${MessageQueueSettings.REDIS_PREFIX}=test"])
 @Testcontainers
 @ContextConfiguration(initializers = [RedisStandAloneMultiQueueTest.Initializer::class])
-@Import(RedisConfiguration::class)
-class RedisStandAloneMultiQueueTest: AbstractMultiQueueTest<RedisMultiQueue>()
+@Import(*[QueueConfiguration::class, LoggingConfiguration::class, RedisConfiguration::class, AbstractMultiQueueTest.AbstractMultiQueueTestConfiguration::class])
+class RedisStandAloneMultiQueueTest: AbstractMultiQueueTest()
 {
     companion object
     {
@@ -88,49 +90,6 @@ class RedisStandAloneMultiQueueTest: AbstractMultiQueueTest<RedisMultiQueue>()
             TestPropertyValues.of(
                 "${MessageQueueSettings.REDIS_ENDPOINT}=${redis.host}:${redis.getMappedPort(REDIS_PORT)}"
             ).applyTo(configurableApplicationContext.environment)
-        }
-    }
-
-    /**
-     * A Spring configuration that is used for this test class.
-     * Creates a [RedisStandaloneConfiguration] as the [RedisConnectionFactory] [Bean].
-     *
-     * This is specifically creating the [RedisMultiQueue] to be autowired in the parent
-     * class and used in all the tests.
-     *
-     * @author github.com/KyleGonzalez
-     */
-    @TestConfiguration
-    internal class RedisStandAloneTestConfiguration
-    {
-        @Autowired
-        @Lazy
-        lateinit var connectionFactory: RedisConnectionFactory
-
-        @Autowired
-        @Lazy
-        lateinit var messageQueueSettings: MessageQueueSettings
-
-        /**
-         * The bean initialise here will have all its properties overridden by environment variables.
-         * Don't set them here, set them in the [WebMvcTest.properties].
-         */
-        @Bean
-        @Lazy
-        open fun getMessageQueueSettingsBean(): MessageQueueSettings
-        {
-            return MessageQueueSettings()
-        }
-
-        /**
-         * The bean initialise here will have all its properties overridden by environment variables.
-         * Don't set them here, set them in the [WebMvcTest.properties].
-         */
-        @Bean
-        @Lazy
-        open fun getRedisMultiQueue(): RedisMultiQueue
-        {
-            return RedisMultiQueue()
         }
     }
 

--- a/src/test/kotlin/au/kilemon/messagequeue/queue/inmemory/InMemoryMultiQueueTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/queue/inmemory/InMemoryMultiQueueTest.kt
@@ -1,11 +1,17 @@
 package au.kilemon.messagequeue.queue.inmemory
 
+import au.kilemon.messagequeue.configuration.QueueConfiguration
+import au.kilemon.messagequeue.logging.LoggingConfiguration
 import au.kilemon.messagequeue.queue.AbstractMultiQueueTest
 import au.kilemon.messagequeue.queue.MultiQueue
+import au.kilemon.messagequeue.settings.MessageQueueSettings
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Lazy
 import org.springframework.test.context.junit.jupiter.SpringExtension
 
 
@@ -15,26 +21,9 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
  * @author github.com/KyleGonzalez
  */
 @ExtendWith(SpringExtension::class)
-class InMemoryMultiQueueTest: AbstractMultiQueueTest<InMemoryMultiQueue>()
+@Import( *[QueueConfiguration::class, LoggingConfiguration::class, AbstractMultiQueueTest.AbstractMultiQueueTestConfiguration::class] )
+class InMemoryMultiQueueTest: AbstractMultiQueueTest()
 {
-    /**
-     * A Spring configuration that is used for this test class.
-     *
-     * This is specifically creating the [InMemoryMultiQueue] to be autowired in the parent
-     * class and used in all the tests.
-     *
-     * @author github.com/KyleGonzalez
-     */
-    @TestConfiguration
-    internal class InMemoryTestConfiguration
-    {
-        @Bean
-        open fun getInMemoryMultiQueue(): InMemoryMultiQueue
-        {
-            return InMemoryMultiQueue()
-        }
-    }
-
     /**
      * Ensure the [MultiQueue] is cleared before each test.
      */

--- a/src/test/kotlin/au/kilemon/messagequeue/queue/sql/AbstractSqlMultiQueueTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/queue/sql/AbstractSqlMultiQueueTest.kt
@@ -1,5 +1,7 @@
 package au.kilemon.messagequeue.queue.sql
 
+import au.kilemon.messagequeue.configuration.QueueConfiguration
+import au.kilemon.messagequeue.configuration.cache.redis.RedisConfiguration
 import au.kilemon.messagequeue.logging.LoggingConfiguration
 import au.kilemon.messagequeue.queue.AbstractMultiQueueTest
 import au.kilemon.messagequeue.settings.MessageQueueSettings
@@ -33,44 +35,4 @@ import org.testcontainers.junit.jupiter.Testcontainers
 @Testcontainers
 @DataJpaTest(properties = ["${MessageQueueSettings.MULTI_QUEUE_TYPE}=SQL", "spring.jpa.hibernate.ddl-auto=create", "spring.autoconfigure.exclude="])
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Import(LoggingConfiguration::class)
-abstract class AbstractSqlMultiQueueTest: AbstractMultiQueueTest<SqlMultiQueue>()
-{
-    /**
-     * A Spring configuration that is used for this test class.
-     *
-     * This is specifically creating the [SqlMultiQueue] to be autowired in the parent
-     * class and used in all the tests.
-     *
-     * @author github.com/KyleGonzalez
-     */
-    @TestConfiguration
-    class SqlMultiQueueTestConfiguration
-    {
-        @Autowired
-        @Lazy
-        lateinit var messageQueueSettings: MessageQueueSettings
-
-        /**
-         * The bean initialise here will have all its properties overridden by environment variables.
-         * Don't set them here, set them in the [WebMvcTest.properties].
-         */
-        @Bean
-        @Lazy
-        open fun getMessageQueueSettingsBean(): MessageQueueSettings
-        {
-            return MessageQueueSettings()
-        }
-
-        /**
-         * The bean initialise here will have all its properties overridden by environment variables.
-         * Don't set them here, set them in the [WebMvcTest.properties].
-         */
-        @Bean
-        @Lazy
-        open fun getSqlMultiQueue(): SqlMultiQueue
-        {
-            return SqlMultiQueue()
-        }
-    }
-}
+abstract class AbstractSqlMultiQueueTest: AbstractMultiQueueTest()

--- a/src/test/kotlin/au/kilemon/messagequeue/queue/sql/MySqlMultiQueueTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/queue/sql/MySqlMultiQueueTest.kt
@@ -1,5 +1,8 @@
 package au.kilemon.messagequeue.queue.sql
 
+import au.kilemon.messagequeue.configuration.QueueConfiguration
+import au.kilemon.messagequeue.logging.LoggingConfiguration
+import au.kilemon.messagequeue.queue.AbstractMultiQueueTest
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -18,7 +21,7 @@ import java.util.HashMap
  * @author github.com/KyleGonzalez
  */
 @ContextConfiguration(initializers = [MySqlMultiQueueTest.Initializer::class])
-@Import(AbstractSqlMultiQueueTest.SqlMultiQueueTestConfiguration::class)
+@Import( *[QueueConfiguration::class, LoggingConfiguration::class, AbstractMultiQueueTest.AbstractMultiQueueTestConfiguration::class] )
 class MySqlMultiQueueTest : AbstractSqlMultiQueueTest()
 {
     companion object

--- a/src/test/kotlin/au/kilemon/messagequeue/queue/sql/PostgreSqlMultiQueueTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/queue/sql/PostgreSqlMultiQueueTest.kt
@@ -1,5 +1,8 @@
 package au.kilemon.messagequeue.queue.sql
 
+import au.kilemon.messagequeue.configuration.QueueConfiguration
+import au.kilemon.messagequeue.logging.LoggingConfiguration
+import au.kilemon.messagequeue.queue.AbstractMultiQueueTest
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -19,7 +22,7 @@ import java.util.*
  * @author github.com/KyleGonzalez
  */
 @ContextConfiguration(initializers = [PostgreSqlMultiQueueTest.Initializer::class])
-@Import(AbstractSqlMultiQueueTest.SqlMultiQueueTestConfiguration::class)
+@Import( *[QueueConfiguration::class, LoggingConfiguration::class, AbstractMultiQueueTest.AbstractMultiQueueTestConfiguration::class] )
 class PostgreSqlMultiQueueTest: AbstractSqlMultiQueueTest()
 {
     companion object

--- a/src/test/kotlin/au/kilemon/messagequeue/rest/controller/MessageQueueControllerTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/rest/controller/MessageQueueControllerTest.kt
@@ -1,10 +1,11 @@
 package au.kilemon.messagequeue.rest.controller
 
+import au.kilemon.messagequeue.configuration.QueueConfiguration
 import au.kilemon.messagequeue.logging.LoggingConfiguration
-import au.kilemon.messagequeue.rest.model.Payload
-import au.kilemon.messagequeue.rest.model.PayloadEnum
 import au.kilemon.messagequeue.message.QueueMessage
 import au.kilemon.messagequeue.queue.MultiQueue
+import au.kilemon.messagequeue.rest.model.Payload
+import au.kilemon.messagequeue.rest.model.PayloadEnum
 import au.kilemon.messagequeue.rest.response.MessageResponse
 import au.kilemon.messagequeue.settings.MessageQueueSettings
 import com.google.gson.Gson
@@ -26,7 +27,6 @@ import org.springframework.test.web.servlet.MvcResult
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import java.util.*
-import kotlin.collections.ArrayList
 
 /**
  * A test class for the [MessageQueueController].
@@ -36,7 +36,7 @@ import kotlin.collections.ArrayList
  */
 @ExtendWith(SpringExtension::class)
 @WebMvcTest(controllers = [MessageQueueController::class], properties = ["${MessageQueueSettings.MULTI_QUEUE_TYPE}=IN_MEMORY"])
-@Import(LoggingConfiguration::class)
+@Import(*[QueueConfiguration::class, LoggingConfiguration::class])
 class MessageQueueControllerTest
 {
     /**


### PR DESCRIPTION
Use this Configuration class in unit test to remove excess configuration and to actually test the running code.