### PR TITLE
Update "/all" endpoint to provide "payload" as "***" instead of null …

### DIFF
--- a/src/main/kotlin/au/kilemon/messagequeue/message/QueueMessage.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/message/QueueMessage.kt
@@ -87,6 +87,7 @@ class QueueMessage(payload: Any?, @Column(nullable = false) var type: String, @C
             newMessage.type = type
             newMessage.assignedTo = assignedTo
             newMessage.uuid = uuid
+            newMessage.payload = "***" // Mark as stars to indicate that it is there but not returned
             return newMessage
         }
         resolvePayloadObject()

--- a/src/main/kotlin/au/kilemon/messagequeue/queue/inmemory/InMemoryMultiQueue.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/queue/inmemory/InMemoryMultiQueue.kt
@@ -52,29 +52,6 @@ open class InMemoryMultiQueue : MultiQueue, HasLogger
         return queueForType
     }
 
-    override fun getAssignedMessagesForType(queueType: String, assignedTo: String?): Queue<QueueMessage>
-    {
-        val queue = ConcurrentLinkedQueue<QueueMessage>()
-        val queueForType = getQueueForType(queueType)
-        if (assignedTo == null)
-        {
-            queue.addAll(queueForType.stream().filter { message -> message.assignedTo != null }.collect(Collectors.toList()))
-        }
-        else
-        {
-            queue.addAll(queueForType.stream().filter { message -> message.assignedTo == assignedTo }.collect(Collectors.toList()))
-        }
-        return queue
-    }
-
-    override fun getUnassignedMessagesForType(queueType: String): Queue<QueueMessage>
-    {
-        val queue = ConcurrentLinkedQueue<QueueMessage>()
-        val queueForType = getQueueForType(queueType)
-        queue.addAll(queueForType.stream().filter { message -> message.assignedTo == null }.collect(Collectors.toList()))
-        return queue
-    }
-
     override fun performHealthCheckInternal()
     {
         // Nothing to check for the in-memory storage since there is no external storage that needs to be checked

--- a/src/main/kotlin/au/kilemon/messagequeue/queue/sql/SqlMultiQueue.kt
+++ b/src/main/kotlin/au/kilemon/messagequeue/queue/sql/SqlMultiQueue.kt
@@ -46,6 +46,9 @@ class SqlMultiQueue : MultiQueue, HasLogger
         return ConcurrentLinkedQueue(entries.map { entry -> entry.resolvePayloadObject() })
     }
 
+    /**
+     * Overriding since we can filter via the DB query.
+     */
     override fun getAssignedMessagesForType(queueType: String, assignedTo: String?): Queue<QueueMessage>
     {
         val entries = if (assignedTo == null)
@@ -60,6 +63,9 @@ class SqlMultiQueue : MultiQueue, HasLogger
         return ConcurrentLinkedQueue(entries.map { entry -> entry.resolvePayloadObject() })
     }
 
+    /**
+     * Overriding since we can filter via the DB query.
+     */
     override fun getUnassignedMessagesForType(queueType: String): Queue<QueueMessage>
     {
         val entries = queueMessageRepository.findByTypeAndAssignedToIsNullOrderByIdAsc(queueType)

--- a/src/test/kotlin/au/kilemon/messagequeue/queue/AbstractMultiQueueTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/queue/AbstractMultiQueueTest.kt
@@ -607,15 +607,18 @@ abstract class AbstractMultiQueueTest
         val message2 = QueueMessage(Payload("some more data", 2, false, PayloadEnum.B), type)
         val message3 = QueueMessage(Payload("some more data data", 3, false, PayloadEnum.C), type)
 
-        // Assign message 1 and 2
+        // Assign message 1
         val assignedTo = "me"
         message.assignedTo = assignedTo
-        message2.assignedTo = assignedTo
         Assertions.assertNull(message3.assignedTo)
 
         Assertions.assertTrue(multiQueue.add(message))
         Assertions.assertTrue(multiQueue.add(message2))
         Assertions.assertTrue(multiQueue.add(message3))
+
+        // Assign and update message 2, to check that even if its changed and re-enqueued that it retains the correct order
+        message2.assignedTo = assignedTo
+        multiQueue.persistMessage(message2)
 
         // Ensure all messages are in the queue
         val messagesInSubQueue = multiQueue.getQueueForType(type)
@@ -649,7 +652,6 @@ abstract class AbstractMultiQueueTest
         val assignedTo = "me"
         val assignedTo2 = "me2"
         message.assignedTo = assignedTo
-        message2.assignedTo = assignedTo
         message3.assignedTo = assignedTo2
         Assertions.assertNull(message4.assignedTo)
 
@@ -657,6 +659,10 @@ abstract class AbstractMultiQueueTest
         Assertions.assertTrue(multiQueue.add(message2))
         Assertions.assertTrue(multiQueue.add(message3))
         Assertions.assertTrue(multiQueue.add(message4))
+
+        // Assign and update message 2, to check that even if its changed and re-enqueued that it retains the correct order
+        message2.assignedTo = assignedTo
+        multiQueue.persistMessage(message2)
 
         // Ensure all messages are in the queue
         val messagesInSubQueue = multiQueue.getQueueForType(type)
@@ -690,13 +696,17 @@ abstract class AbstractMultiQueueTest
         val assignedTo = "you"
         message.assignedTo = assignedTo
         message2.assignedTo = assignedTo
-        Assertions.assertNull(message3.assignedTo)
+        message3.assignedTo = assignedTo
         Assertions.assertNull(message4.assignedTo)
 
         Assertions.assertTrue(multiQueue.add(message))
         Assertions.assertTrue(multiQueue.add(message2))
         Assertions.assertTrue(multiQueue.add(message3))
         Assertions.assertTrue(multiQueue.add(message4))
+
+        // Now unassign message 3 to make sure persisted messages are ordered properly after they are changed
+        message3.assignedTo = null
+        multiQueue.persistMessage(message3)
 
         // Ensure all messages are in the queue
         val messagesInSubQueue = multiQueue.getQueueForType(type)

--- a/src/test/kotlin/au/kilemon/messagequeue/rest/controller/MessageQueueControllerTest.kt
+++ b/src/test/kotlin/au/kilemon/messagequeue/rest/controller/MessageQueueControllerTest.kt
@@ -360,7 +360,7 @@ class MessageQueueControllerTest
         keys.values.forEach { detailList -> Assertions.assertEquals(1, detailList.size) }
         Assertions.assertEquals(entries.first[0].removePayload(false).uuid, keys[type]!![0].uuid)
         // Since we did not pass a detailed flag value, ensure the payload is null
-        Assertions.assertNull(entries.first[0].removePayload(false).payload)
+        Assertions.assertEquals("***", entries.first[0].removePayload(false).payload)
         Assertions.assertEquals(entries.first[0].removePayload(false).assignedTo, keys[type]!![0].assignedTo)
         Assertions.assertEquals(entries.first[0].removePayload(false).type, keys[type]!![0].type)
     }


### PR DESCRIPTION
…when detailed messages are not are requested.

Fix Redis message ordering when retrieving unassigned and assigned messages. Move common code to MultiQueue interface default implementation. Update tests to cover changes.